### PR TITLE
Time format change

### DIFF
--- a/python/fb_ads_library_api.py
+++ b/python/fb_ads_library_api.py
@@ -100,10 +100,10 @@ class FbAdsLibraryTraversal:
 
             filtered = list(
                 filter(
-                    lambda ad_archive: datetime.strptime(
-                        ad_archive["ad_delivery_start_time"], "%Y-%m-%dT%H:%M:%S%z"
+                    lambda ad_archive: ("ad_delivery_start_time" in ad_archive) and (
+                        datetime.strptime(ad_archive["ad_delivery_start_time"], "%Y-%m-%d"
                     ).timestamp()
-                    >= start_time_cutoff_after,
+                    >= start_time_cutoff_after),
                     response_data["data"],
                 )
             )


### PR DESCRIPTION
Fixed time regex that was broken due to time format change in the API since Sept 1st 2020.
Also added a check on missing ad_delivery_start_time as some results do not have it.