### PR TITLE
Updating tool to work with v14.0

### DIFF
--- a/python/fb_ads_library_api.py
+++ b/python/fb_ads_library_api.py
@@ -26,7 +26,7 @@ class FbAdsLibraryTraversal:
         + "fields={}&search_terms={}&ad_reached_countries={}&search_page_ids={}&"
         + "ad_active_status={}&limit={}"
     )
-    default_api_version = "v4.0"
+    default_api_version = "v14.0"
 
     def __init__(
         self,

--- a/python/fb_ads_library_api_utils.py
+++ b/python/fb_ads_library_api_utils.py
@@ -59,7 +59,7 @@ valid_query_fields = [
     "currency",
     "delivery_by_region",
     "demographic_distribution",
-    "funding_entity",
+    "bylines",
     "id",
     "impressions",
     "languages",


### PR DESCRIPTION
The tool still used API version 4 and that made it fail to gather ads in certain cases. Furthermore, I changed the field value "funding_entity" into "bylines", the term now used by the API